### PR TITLE
sepolicy: qti: Address oplus_scheduler denials

### DIFF
--- a/sepolicy/qti/vendor/file.te
+++ b/sepolicy/qti/vendor/file.te
@@ -19,6 +19,9 @@ type vendor_proc_engineer, fs_type, proc_type;
 type vendor_persist_fingerprint_file, file_type;
 type vendor_proc_fingerprint, fs_type, proc_type;
 
+# Performance
+type vendor_proc_oplus_scheduler, fs_type, proc_type;
+
 # Sensors
 type vendor_proc_eng_cali_file, fs_type, proc_type;
 type vendor_proc_oplus_als_file, fs_type, proc_type;

--- a/sepolicy/qti/vendor/genfs_contexts
+++ b/sepolicy/qti/vendor/genfs_contexts
@@ -36,6 +36,9 @@ genfscon proc /oplus_rf    u:object_r:vendor_proc_engineer:s0
 # Fingerprint
 genfscon proc /fp_id    u:object_r:vendor_proc_fingerprint:s0
 
+# Performance
+genfscon proc /oplus_scheduler                        u:object_r:vendor_proc_oplus_scheduler:s0
+
 # Sensors
 genfscon proc /sensor/als_cali                        u:object_r:vendor_proc_oplus_als_file:s0
 genfscon proc /sensor/pressure_cali                   u:object_r:vendor_proc_eng_cali_file:s0

--- a/sepolicy/qti/vendor/hal_oplus_performance_aidl.te
+++ b/sepolicy/qti/vendor/hal_oplus_performance_aidl.te
@@ -13,3 +13,4 @@ hal_attribute_service(vendor_hal_oplus_performance, hal_oplus_performance_aidl_s
 allow vendor_hal_oplus_performance_client hal_oplus_performance_aidl_service:service_manager find;
 
 r_dir_file(hal_oplus_performance_aidl, proc_version)
+rw_dir_file(hal_oplus_performance_aidl, vendor_proc_oplus_scheduler)


### PR DESCRIPTION
We are stuck with using oplus performance hal for audio to work. But it also wants access to oplus_scheduler nodes which might cause issues like stutters or lags during normal usage if denied